### PR TITLE
fix: modernize Claude API call, fix workflow variable reference, and …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Publish affected packages to NPM
         if: github.event_name == 'push'
         run: |
-          echo "Publishing affected packages with tag: $NEW_VERSION to NPM"
+          echo "Publishing affected packages with tag: ${{ steps.version_update.outputs.new_version }} to NPM"
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/spec-workflow-mcp",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "MCP server for spec-driven development workflow with real-time web dashboard",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
…bump version to prevent tag collision

- Replace legacy https module with fetch API in analyze-version-bump.js
- Fix workflow variable reference using proper GitHub Actions syntax
- Bump version to 0.2.9, the CI was failing because somehow the git tag v0.2.9 has already been pushed, despite the current package.json version being 0.2.8. By manually bumping the version to 0.2.9 we should fix the bug, and have the next git tag be v0.2.10. See CI error here: https://github.com/Uniswap/spec-workflow-mcp/actions/runs/17837803855/job/50719319088