### PR TITLE
update autostart handling to open web dashboard at correct time

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -816,10 +816,8 @@ export class DashboardServer {
     // Start server
     await this.app.listen({ port: this.actualPort, host: "0.0.0.0" });
 
-    // Open browser if requested
-    if (this.options.autoOpen) {
-      await open(`http://localhost:${this.actualPort}`);
-    }
+    // Note: Browser opening is now handled externally via openBrowser() method
+    // to allow lazy opening on first spec-workflow-guide tool call
 
     return `http://localhost:${this.actualPort}`;
   }
@@ -949,5 +947,21 @@ export class DashboardServer {
 
   getUrl(): string {
     return `http://localhost:${this.actualPort}`;
+  }
+
+  /**
+   * Opens the dashboard in the default browser.
+   * This is called separately from start() to allow lazy browser opening
+   * (e.g., on first spec-workflow-guide tool call instead of on server startup).
+   */
+  async openBrowser(): Promise<void> {
+    if (this.actualPort > 0) {
+      try {
+        await open(`http://localhost:${this.actualPort}`);
+      } catch (error: any) {
+        console.warn('Failed to open browser automatically:', error.message);
+        console.log(`Dashboard is running at: http://localhost:${this.actualPort}`);
+      }
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ MODES OF OPERATION:
    spec-workflow-mcp --AutoStartDashboard --port 3456
    spec-workflow-mcp ~/my-project --AutoStartDashboard
 
-   Starts MCP server and automatically launches dashboard in browser.
+   Starts MCP server and launches dashboard in browser on first spec-workflow-guide tool call.
    Note: Server and dashboard shut down when MCP client disconnects.
 
 3. Dashboard Only Mode:

--- a/src/server.ts
+++ b/src/server.ts
@@ -148,8 +148,12 @@ Remember: The spec-workflow-guide tool contains all the detailed instructions yo
           // Create session tracking (overwrites any existing session.json)
           await this.sessionManager!.createSession(this.dashboardUrl);
 
-          await this.dashboardServer.openBrowser();
-          console.log('Dashboard opened in browser (first spec-workflow-guide call)');
+          try {
+            await this.dashboardServer.openBrowser();
+            console.log('Dashboard opened in browser (first spec-workflow-guide call)');
+          } catch (error) {
+            console.error('Failed to open browser:', error);
+          }
         }
 
         // Create dynamic context with current dashboard URL

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,9 +85,6 @@ Remember: The spec-workflow-guide tool contains all the detailed instructions yo
         });
         this.dashboardUrl = await this.dashboardServer.start();
         
-        // Create session tracking (overwrites any existing session.json)
-        await this.sessionManager.createSession(this.dashboardUrl);
-        
         // Log dashboard startup info
         console.log(`Dashboard auto-started at: ${this.dashboardUrl}`);
       }
@@ -147,6 +144,10 @@ Remember: The spec-workflow-guide tool contains all the detailed instructions yo
             this.dashboardServer &&
             this.dashboardUrl) {
           this.browserOpened = true; // Set flag before awaiting to prevent race conditions
+
+          // Create session tracking (overwrites any existing session.json)
+          await this.sessionManager!.createSession(this.dashboardUrl);
+
           await this.dashboardServer.openBrowser();
           console.log('Dashboard opened in browser (first spec-workflow-guide call)');
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ export class SpecWorkflowMCPServer {
   private dashboardUrl?: string;
   private sessionManager?: SessionManager;
   private dashboardMonitoringInterval?: NodeJS.Timeout;
+  private browserOpened: boolean = false;
 
   constructor() {
     this.server = new Server({
@@ -140,6 +141,16 @@ Remember: The spec-workflow-guide tool contains all the detailed instructions yo
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       try {
+        // Open browser on first spec-workflow-guide call if auto-start is enabled
+        if (request.params.name === 'spec-workflow-guide' &&
+            !this.browserOpened &&
+            this.dashboardServer &&
+            this.dashboardUrl) {
+          this.browserOpened = true; // Set flag before awaiting to prevent race conditions
+          await this.dashboardServer.openBrowser();
+          console.log('Dashboard opened in browser (first spec-workflow-guide call)');
+        }
+
         // Create dynamic context with current dashboard URL
         const dynamicContext = {
           ...context,


### PR DESCRIPTION
Completes DEV-82

Prior to this commit, if the user had installed the spec-workflow-mcp and then started claude, claude would automatically open up the web ui dashboard for the spec-workflow-mcp. This is unexpected, because this web ui should only open if the user actually uses the spec-workflow mcp.

This was happening because of how claude code's lifecycle works; when it starts up, it optimistically calls each of the MCP startup commands it has. And because the startup command also opened the dashboard in the user's browser, the user would inexplicably see the dashboard open every time the user opens up claude code.

Now it only opens when the user asks to use the spec-workflow-mcp

To test this:

1. `git pull fix-autostart-bug`
2. `npm run build`
3. replace your existing mcpServers.spec-workflow config in your `~/.claude.json` file to be:
```
 "spec-workflow": {
      "type": "stdio",
      "command": "node",
      "args": [
        "/path/to/spec-workflow-mcp/dist/index.js",
        "--AutoStartDashboard"
      ],
      "env": {}
    },
```
4. run `claude mcp list` and make sure spec-workflow is connected
5. Finally, open up `claude`, you should see it NOT open up the spec-workflow's webui. Then, tell claude to use the spec-workflow-mcp to build something, and you SHOULD see the webui open.