### PR TITLE
fix(dashboard): block path traversal in :name routes and sanitize markdown XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@modelcontextprotocol/sdk": "^0.5.0",
         "chokidar": "^3.5.3",
         "clsx": "^2.1.1",
+        "dompurify": "^3.4.1",
         "fastify": "^4.24.3",
         "highlight.js": "^11.9.0",
         "markdown-it": "^14.1.0",
@@ -3674,9 +3675,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@modelcontextprotocol/sdk": "^0.5.0",
     "chokidar": "^3.5.3",
     "clsx": "^2.1.1",
+    "dompurify": "^3.4.1",
     "fastify": "^4.24.3",
     "highlight.js": "^11.9.0",
     "markdown-it": "^14.1.0",

--- a/src/core/path-utils.ts
+++ b/src/core/path-utils.ts
@@ -1,7 +1,81 @@
-import { join, normalize, sep, resolve } from 'path';
+import { join, normalize, sep, resolve, isAbsolute } from 'path';
 import { access, stat, mkdir } from 'fs/promises';
 import { constants } from 'fs';
 import { gitignoreManager } from './gitignore-manager.js';
+
+export class InvalidSpecNameError extends Error {
+  constructor(message = 'Invalid spec name') {
+    super(message);
+    this.name = 'InvalidSpecNameError';
+  }
+}
+
+export function isSafeSpecName(name: unknown): name is string {
+  if (typeof name !== 'string' || name.length === 0 || name.length > 255) return false;
+  if (name.includes('/') || name.includes('\\') || name.includes('\0')) return false;
+  if (name === '.' || name === '..') return false;
+  if (name.startsWith('.')) return false;
+  return true;
+}
+
+export function assertSafeSpecName(name: unknown): asserts name is string {
+  if (!isSafeSpecName(name)) {
+    throw new InvalidSpecNameError();
+  }
+}
+
+function assertContained(baseDir: string, candidate: string): void {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+  const resolvedBase = resolve(baseDir);
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+  const resolvedCandidate = resolve(candidate);
+  if (resolvedCandidate !== resolvedBase && !resolvedCandidate.startsWith(resolvedBase + sep)) {
+    throw new InvalidSpecNameError();
+  }
+}
+
+export function safeResolveSpecPath(projectPath: string, name: string): string {
+  assertSafeSpecName(name);
+  const baseDir = PathUtils.getSpecPath(projectPath, '');
+  const candidate = PathUtils.getSpecPath(projectPath, name);
+  assertContained(baseDir, candidate);
+  return candidate;
+}
+
+export function safeResolveArchiveSpecPath(projectPath: string, name: string): string {
+  assertSafeSpecName(name);
+  const baseDir = PathUtils.getArchiveSpecsPath(projectPath);
+  const candidate = PathUtils.getArchiveSpecPath(projectPath, name);
+  assertContained(baseDir, candidate);
+  return candidate;
+}
+
+/**
+ * Resolve `candidate` (absolute or relative-to-baseDir) and return the
+ * absolute path only if it stays inside baseDir. Returns null on traversal,
+ * non-string input, or any resolution error. Use this for filesystem paths
+ * derived from stored data (e.g. approval JSON `filePath`) where the field
+ * is expected to point inside the project but cannot be assumed safe.
+ */
+export function safeResolveUnder(baseDir: string, candidate: unknown): string | null {
+  if (typeof candidate !== 'string' || candidate.length === 0) return null;
+  if (candidate.includes('\0')) return null;
+  try {
+    // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+    const resolvedBase = resolve(baseDir);
+    const resolvedCandidate = isAbsolute(candidate)
+      // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+      ? resolve(candidate)
+      // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+      : resolve(baseDir, candidate);
+    if (resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(resolvedBase + sep)) {
+      return resolvedCandidate;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
 
 export class PathUtils {
   static getWorkflowRoot(projectPath: string): string {

--- a/src/dashboard/approval-storage.ts
+++ b/src/dashboard/approval-storage.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { promises as fs } from 'fs';
 import { join, isAbsolute, resolve } from 'path';
 import chokidar from 'chokidar';
-import { PathUtils } from '../core/path-utils.js';
+import { PathUtils, safeResolveUnder } from '../core/path-utils.js';
 
 export interface ApprovalComment {
   type: 'selection' | 'general';
@@ -198,11 +198,16 @@ export class ApprovalStorage extends EventEmitter {
       throw new Error(`Approval ${originalId} has no file path for revision`);
     }
 
-    // Read the current file content for revision history
-    const filePath = isAbsolute(originalApproval.filePath) 
-      ? originalApproval.filePath 
-      : join(this.projectPath, originalApproval.filePath);
-    
+    // Resolve the stored filePath, but only accept the result if it stays
+    // inside the project root. The approval JSON could have been corrupted
+    // or written by a non-trusted local process — defense in depth on read.
+    const filePath = safeResolveUnder(this.projectPath, originalApproval.filePath);
+    if (!filePath) {
+      throw new Error(
+        `Approval ${originalId} has a filePath outside the project root`
+      );
+    }
+
     let currentContent = '';
     try {
       currentContent = await fs.readFile(filePath, 'utf-8');

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -13,6 +13,15 @@ import { findAvailablePort, validateAndCheckPort } from "./utils.js";
 import { ApprovalStorage } from "./approval-storage.js";
 import { parseTasksFromMarkdown } from "../core/task-parser.js";
 import { SpecArchiveService } from "../core/archive-service.js";
+import {
+  InvalidSpecNameError,
+  isSafeSpecName,
+  safeResolveArchiveSpecPath,
+  safeResolveSpecPath,
+  safeResolveUnder,
+} from "../core/path-utils.js";
+
+const INVALID_SPEC_NAME_MESSAGE = "Invalid spec name";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -153,6 +162,10 @@ export class DashboardServer {
 
     this.app.post("/api/specs/:name/archive", async (request, reply) => {
       const { name } = request.params as { name: string };
+      if (!isSafeSpecName(name)) {
+        reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        return;
+      }
 
       try {
         await this.archiveService.archiveSpec(name);
@@ -171,6 +184,10 @@ export class DashboardServer {
 
     this.app.post("/api/specs/:name/unarchive", async (request, reply) => {
       const { name } = request.params as { name: string };
+      if (!isSafeSpecName(name)) {
+        reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        return;
+      }
 
       try {
         await this.archiveService.unarchiveSpec(name);
@@ -203,26 +220,36 @@ export class DashboardServer {
             .send({ error: "Approval not found or no file path" });
         }
 
-        // Try several resolution strategies for robustness across environments
-        const candidates: string[] = [];
+        // Resolve candidate paths and require each to stay inside the project
+        // root. Even though the dashboard write APIs cannot forge approval
+        // JSONs (path-traversal is blocked above), `approval.filePath` was
+        // produced by an MCP tool earlier in time and is treated as untrusted
+        // here on read. safeResolveUnder rejects anything that would escape.
+        const projectRoot = this.approvalStorage.projectPath;
         const p = approval.filePath;
-        // 1) As provided if absolute or relative to project root
-        candidates.push(join(this.approvalStorage.projectPath, p));
-        // 2) If path is already absolute, try it directly (join with absolute will normalize on some platforms)
+        const candidates: string[] = [];
+        const c1 = safeResolveUnder(projectRoot, p);
+        if (c1) candidates.push(c1);
         if (p.startsWith("/") || p.match(/^[A-Za-z]:[\\\/]/)) {
-          candidates.push(p);
+          const c2 = safeResolveUnder(projectRoot, p);
+          if (c2 && !candidates.includes(c2)) candidates.push(c2);
         }
-        // 3) If not already under .spec-workflow, try under that root
         if (!p.includes(".spec-workflow")) {
-          candidates.push(
-            join(this.approvalStorage.projectPath, ".spec-workflow", p)
-          );
+          const c3 = safeResolveUnder(projectRoot, join(".spec-workflow", p));
+          if (c3 && !candidates.includes(c3)) candidates.push(c3);
+        }
+
+        if (candidates.length === 0) {
+          return reply.code(400).send({
+            error: "Approval filePath is outside the project root",
+          });
         }
 
         let content: string | null = null;
         let resolvedPath: string | null = null;
         for (const candidate of candidates) {
           try {
+            // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
             const data = await fs.readFile(candidate, "utf-8");
             content = data;
             resolvedPath = candidate;
@@ -265,6 +292,10 @@ export class DashboardServer {
 
     this.app.get("/api/specs/:name", async (request, reply) => {
       const { name } = request.params as { name: string };
+      if (!isSafeSpecName(name)) {
+        reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        return;
+      }
       const spec = await this.parser.getSpec(name);
       if (!spec) {
         reply.code(404).send({ error: "Spec not found" });
@@ -285,13 +316,14 @@ export class DashboardServer {
         return;
       }
 
-      const docPath = join(
-        this.options.projectPath,
-        ".spec-workflow",
-        "specs",
-        name,
-        `${document}.md`
-      );
+      let specDir: string;
+      try {
+        specDir = safeResolveSpecPath(this.options.projectPath, name);
+      } catch {
+        reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        return;
+      }
+      const docPath = join(specDir, `${document}.md`);
 
       try {
         const content = await readFile(docPath, "utf-8");
@@ -320,22 +352,17 @@ export class DashboardServer {
         return;
       }
 
-      const docPath = join(
-        this.options.projectPath,
-        ".spec-workflow",
-        "specs",
-        name,
-        `${document}.md`
-      );
+      let specDir: string;
+      try {
+        specDir = safeResolveSpecPath(this.options.projectPath, name);
+      } catch {
+        reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        return;
+      }
+      const docPath = join(specDir, `${document}.md`);
 
       try {
         // Ensure the spec directory exists
-        const specDir = join(
-          this.options.projectPath,
-          ".spec-workflow",
-          "specs",
-          name
-        );
         await fs.mkdir(specDir, { recursive: true });
 
         // Write the content to file
@@ -370,24 +397,17 @@ export class DashboardServer {
           return;
         }
 
-        const docPath = join(
-          this.options.projectPath,
-          ".spec-workflow",
-          "archive",
-          "specs",
-          name,
-          `${document}.md`
-        );
+        let specDir: string;
+        try {
+          specDir = safeResolveArchiveSpecPath(this.options.projectPath, name);
+        } catch {
+          reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+          return;
+        }
+        const docPath = join(specDir, `${document}.md`);
 
         try {
           // Ensure the archived spec directory exists
-          const specDir = join(
-            this.options.projectPath,
-            ".spec-workflow",
-            "archive",
-            "specs",
-            name
-          );
           await fs.mkdir(specDir, { recursive: true });
 
           // Write the content to file
@@ -408,12 +428,13 @@ export class DashboardServer {
     // Get all spec documents for real-time viewing
     this.app.get("/api/specs/:name/all", async (request, reply) => {
       const { name } = request.params as { name: string };
-      const specDir = join(
-        this.options.projectPath,
-        ".spec-workflow",
-        "specs",
-        name
-      );
+      let specDir: string;
+      try {
+        specDir = safeResolveSpecPath(this.options.projectPath, name);
+      } catch {
+        reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        return;
+      }
       const documents = ["requirements", "design", "tasks"];
       const result: Record<
         string,
@@ -440,13 +461,13 @@ export class DashboardServer {
     // Get all archived spec documents for read-only viewing
     this.app.get("/api/specs/:name/all/archived", async (request, reply) => {
       const { name } = request.params as { name: string };
-      const specDir = join(
-        this.options.projectPath,
-        ".spec-workflow",
-        "archive",
-        "specs",
-        name
-      );
+      let specDir: string;
+      try {
+        specDir = safeResolveArchiveSpecPath(this.options.projectPath, name);
+      } catch {
+        reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        return;
+      }
       const documents = ["requirements", "design", "tasks"];
       const result: Record<
         string,
@@ -550,6 +571,12 @@ export class DashboardServer {
     // Get task progress for a specific spec
     this.app.get("/api/specs/:name/tasks/progress", async (request, reply) => {
       const { name } = request.params as { name: string };
+      let specDir: string;
+      try {
+        specDir = safeResolveSpecPath(this.options.projectPath, name);
+      } catch {
+        return reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+      }
 
       try {
         const spec = await this.parser.getSpec(name);
@@ -558,13 +585,7 @@ export class DashboardServer {
         }
 
         // Parse tasks.md file for detailed task information
-        const tasksPath = join(
-          this.options.projectPath,
-          ".spec-workflow",
-          "specs",
-          name,
-          "tasks.md"
-        );
+        const tasksPath = join(specDir, "tasks.md");
         const tasksContent = await readFile(tasksPath, "utf-8");
         const parseResult = parseTasksFromMarkdown(tasksContent);
 
@@ -610,14 +631,15 @@ export class DashboardServer {
           });
         }
 
+        let specDir: string;
         try {
-          const tasksPath = join(
-            this.options.projectPath,
-            ".spec-workflow",
-            "specs",
-            name,
-            "tasks.md"
-          );
+          specDir = safeResolveSpecPath(this.options.projectPath, name);
+        } catch {
+          return reply.code(400).send({ error: INVALID_SPEC_NAME_MESSAGE });
+        }
+
+        try {
+          const tasksPath = join(specDir, "tasks.md");
 
           // Check if tasks file exists
           let tasksContent: string;
@@ -813,8 +835,10 @@ export class DashboardServer {
       console.log(`Using ephemeral port: ${this.actualPort}`);
     }
 
-    // Start server
-    await this.app.listen({ port: this.actualPort, host: "0.0.0.0" });
+    // Start server.
+    // Bind to loopback only — the dashboard offers unauthenticated read/write
+    // of spec documents and is intended for the developer's own machine.
+    await this.app.listen({ port: this.actualPort, host: "127.0.0.1" });
 
     // Note: Browser opening is now handled externally via openBrowser() method
     // to allow lazy opening on first spec-workflow-guide tool call
@@ -886,14 +910,18 @@ export class DashboardServer {
 
   private async broadcastTaskUpdate(specName: string) {
     try {
-      // Get updated task progress for the specific spec
-      const tasksPath = join(
-        this.options.projectPath,
-        ".spec-workflow",
-        "specs",
-        specName,
-        "tasks.md"
-      );
+      // Get updated task progress for the specific spec.
+      // safeResolveSpecPath throws on traversal/invalid names — the watcher
+      // sources specName from on-disk dir entries, but defending here keeps
+      // the invariant local to every filesystem touch.
+      let specDir: string;
+      try {
+        specDir = safeResolveSpecPath(this.options.projectPath, specName);
+      } catch {
+        return;
+      }
+      // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+      const tasksPath = join(specDir, "tasks.md");
       const tasksContent = await readFile(tasksPath, "utf-8");
       const parseResult = parseTasksFromMarkdown(tasksContent);
 

--- a/src/dashboard_frontend/src/modules/markdown/Markdown.tsx
+++ b/src/dashboard_frontend/src/modules/markdown/Markdown.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import MarkdownIt from 'markdown-it';
 import hljs from 'highlight.js/lib/common';
 import mermaid from 'mermaid';
+import DOMPurify from 'dompurify';
 
 type Props = {
   content: string;
@@ -14,8 +15,11 @@ function createMd(): MarkdownIt {
     typographer: true,
     highlight(str, lang) {
       if (lang === 'mermaid') {
-        // Render as mermaid container; actual rendering happens in useEffect
-        return `<div class="mermaid">${str}</div>`;
+        // Escape so attacker-supplied fence content cannot break out of the
+        // mermaid container and inject HTML. Mermaid reads node.textContent
+        // when it later runs, which decodes the entities back to the original
+        // diagram source — so escaping is XSS-safe and behavior-preserving.
+        return `<div class="mermaid">${md.utils.escapeHtml(str)}</div>`;
       }
       if (lang && hljs.getLanguage(lang)) {
         try {
@@ -35,7 +39,7 @@ function createMd(): MarkdownIt {
     const token = tokens[idx];
     const langInfo = token.info ? token.info.trim() : '';
     if (langInfo === 'mermaid') {
-      return `<div class="mermaid">${token.content}</div>`;
+      return `<div class="mermaid">${md.utils.escapeHtml(token.content)}</div>`;
     }
     return fence ? fence(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
   };
@@ -47,8 +51,17 @@ export function Markdown({ content }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [themeState, setThemeState] = useState(0); // Force re-render on theme change
   const md = useMemo(createMd, []);
-  const html = useMemo(() => md.render(typeof content === 'string' ? content : String(content ?? '')),
-    [md, content]);
+  const html = useMemo(() => {
+    const rendered = md.render(typeof content === 'string' ? content : String(content ?? ''));
+    // Sanitize as a defense-in-depth catch-all. The MarkdownIt config already
+    // escapes user content in every emitter (html:false plus md.utils.escapeHtml
+    // in highlight() and the mermaid fence rule), but DOMPurify guards against
+    // a future contributor adding an emitter that forgets to escape.
+    return DOMPurify.sanitize(rendered, {
+      ADD_ATTR: ['target'], // preserve target="_blank" on linkified URLs
+      USE_PROFILES: { html: true, svg: true, svgFilters: true, mathMl: true },
+    });
+  }, [md, content]);
 
   // Listen for theme changes
   useEffect(() => {


### PR DESCRIPTION
## Summary

The dashboard server in `@uniswap/spec-workflow-mcp@0.4.0` exposed unauthenticated read/write/rename primitives to anyone with network reach to the dashboard port — Fastify decoded percent-encoded path separators in the `:name` route param and the handlers fed it straight to `path.join(projectPath, '.spec-workflow', 'specs', name, ...)`. The same write primitive could be chained into stored XSS through unsafe mermaid-fence rendering. Reported on Cantina ([finding #676](https://cantina.xyz/code/f9df94db-c7b1-434b-bb06-d1360abdd1be/findings/676)).

This change closes the network-attacker class entirely (loopback-only bind), validates and contains every `:name`-derived filesystem path, sanitizes rendered markdown, and adds defense-in-depth on the approval-content endpoint.

## What changed

**Loopback-only bind** — `src/dashboard/server.ts` now listens on `127.0.0.1` instead of `0.0.0.0`. The dashboard is a developer-machine tool with no auth; same-network attackers no longer reach it.

**Path-safety primitives** — `src/core/path-utils.ts` gains `isSafeSpecName` (rejects `/`, `\`, NUL, `.`, `..`, leading dot, empty, `>255` chars), `safeResolveSpecPath` / `safeResolveArchiveSpecPath` (resolve + assert containment under specs / archive dir), and `safeResolveUnder` (containment check for arbitrary stored paths). Pairs shape-rejection with effect-rejection — both `path.normalize` collapse-only behavior and any future encoder weirdness are caught.

**Route hardening** — every `:name`-bearing dashboard route runs through validation before any path construction: GET/PUT spec doc (active + archived), GET `/api/specs/:name`, GET `/api/specs/:name/all` (active + archived), POST archive/unarchive, GET task progress, PUT task status, internal `broadcastTaskUpdate`. Steering routes already used a strict allowlist.

**Approval defense-in-depth** — `GET /api/approvals/:id/content` and `ApprovalStorage.createRevision` now route `approval.filePath` through `safeResolveUnder(projectRoot, ...)`. Any candidate that resolves outside the project tree is dropped (or rejected for revision). This isn't reachable from the cantina threat model — `approval.filePath` is set by the MCP `request-approval` tool over stdio, not HTTP — but it removes a latent local-attacker primitive and de-couples future HTTP write surfaces from the safety of stored data.

**Markdown XSS containment** — `src/dashboard_frontend/src/modules/markdown/Markdown.tsx` escapes user content in both mermaid fence emit sites with `md.utils.escapeHtml` (mermaid still renders, since it reads `node.textContent`), and runs the final rendered HTML through DOMPurify before `dangerouslySetInnerHTML`. The escapeHtml + sanitize pair is intentional belt-and-suspenders: per-emitter escape preserves mermaid's diagram source intact (DOMPurify alone would strip the breakout `</div>` and corrupt the diagram), and DOMPurify catches any future emitter that forgets to escape.

## Test plan

Verified end-to-end against a built dashboard process:

- [x] Path-traversal read returns 400 (was 200 with file content)
- [x] Path-traversal write returns 400 (was 200 with file written outside project)
- [x] Outside file untouched after attempted traversal
- [x] Legitimate spec write still 200 + hits expected disk path
- [x] Legitimate spec read still 200 + returns content
- [x] Bind to loopback only — connection on non-loopback IP refused
- [x] Mermaid XSS markdown round-trips correctly through write/read
- [x] Archive endpoint with traversal payload returns 400
- [x] Poisoned approval JSON pointing at `../../outside/secret.txt` is refused with 4xx, secret never appears in response body
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (TypeScript + Vite + static copy)

Manual UI testing of mermaid rendering with sanitization not yet performed — please spot-check the rendered Specs view after merge.

## Session context

### Investigation

Walked the cantina finding plus the three follow-up comments from the reporter. Reproduced each issue against `src/dashboard/server.ts` and `src/core/path-utils.ts`. Confirmed `path.normalize(join(...))` resolves `..` segments rather than rejecting them — the entire premise of `PathUtils.getSpecPath` was a normalization helper, not a safety check.

For the mermaid XSS: confirmed that `MarkdownIt({ html: false })` does NOT save the renderer when the `highlight` callback and `fence` rule emit HTML directly — the `html:false` invariant is bypassed by the renderer's own raw-HTML emission. The breakout `</div><img src=x onerror=...>` inside a mermaid fence escapes the `<div class=\"mermaid\">` container before mermaid runs.

### Approaches evaluated and rejected

- **Add a `--host` CLI flag for opt-in network exposure.** Rejected for now — keeps surface tight; users who need network access can SSH-tunnel. Easy to add later if the use case appears.
- **Drop `dangerouslySetInnerHTML` by switching to `react-markdown`.** Considered (would have replaced the parser entirely, removed the sink, ~50 KB gzip dep). Held off in favor of DOMPurify after discussion — smaller change, maintains MarkdownIt config and existing visual behavior.
- **Refactor mermaid rendering to use refs + `textContent` instead of HTML interpolation.** Possible but invasive; escape-then-decode-via-textContent achieves the same safety with one-line changes.
- **Validate inside `PathUtils.getSpecPath` itself.** Rejected — the helper is also called internally with empty-string `name` (e.g. `PathUtils.getSpecPath(projectPath, '')` to mean \"the specs/ dir\") and from `parser.ts` with names already pulled from `readdir`. Validation belongs at the API boundary, not inside an internal path constructor.

### Constraints discovered

- The reporter's PoCs run against the *published* npm artifact, not source. The `index.js` bundle path needs to be inspected, not just `src/`.
- DOMPurify v3 ships its own type declarations — no `@types/dompurify` needed.
- The branch convention requires `<type>/<short-description>` (set per CLAUDE.md / memory).

### Known limitations

- **No authentication added.** Recommendation #2 from the cantina report (per-session token / random auth secret) is not implemented. Loopback-only bind closes the network-attacker class; auth would defend against same-machine attackers, which is a different and much narrower threat model. Worth doing as a follow-up if the threat model expands.
- **Approval-creation surface (MCP `request-approval` tool) not audited here.** It writes the `filePath` field that this PR now treats as untrusted-on-read. If a future change exposes approval creation over HTTP, the write side will need its own validation. The read side is now safe.
- **Frontend Markdown component lacks unit tests.** The mermaid escape and DOMPurify wiring are exercised manually via the build + the round-trip API verifier. A test that asserts `md.render('\`\`\`mermaid\n</div><img src=x onerror=...>\n\`\`\`')` produces no executable HTML would be a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)